### PR TITLE
change import from longcat_image to diffusers as upstream changes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -67,8 +67,8 @@ class LongCatImageModelLoader(io.ComfyNode):
     def execute(cls, model_path, dtype, enable_cpu_offload, attention_backend) -> io.NodeOutput:
         try:
             from transformers import AutoProcessor
-            from longcat_image.models import LongCatImageTransformer2DModel
-            from longcat_image.pipelines import LongCatImagePipeline, LongCatImageEditPipeline
+            from diffusers.models.transformers.transformer_longcat_image import LongCatImageTransformer2DModel
+            from diffusers import LongCatImagePipeline, LongCatImageEditPipeline
         except ImportError as e:
             raise ImportError(
                 f"Failed to import LongCat-Image dependencies. "


### PR DESCRIPTION
A fix for the problem https://github.com/sooxt98/comfyui_longcat_image/issues/5#issuecomment-3663968310 

I made a fix as upstream meituan-longcat/LongCat-Image change their example code, because last diffusers from git has support for LongCat-Image.